### PR TITLE
Implement skipping of certificate validation for testing purposes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ homepage = "https://github.com/Lachstec/ginmi"
 [lib]
 doctest = false
 
+[features]
+dangerous_configuration = ["dep:hyper", "dep:hyper-rustls", "tower-http/util", "tower-http/add-extension", "dep:rustls-pemfile", "dep:tokio-rustls"]
+
 [dependencies]
 tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros"] }
 prost = "0.12.3"
@@ -26,6 +29,14 @@ tower-service = "0.3.2"
 # Needs to match tonics version of http, else implementations of the Service trait break.
 http = "0.2.0"
 tower = "0.4.13"
+
+# Dependencies for dangerour configuration
+hyper = { version = "0.14", optional = true }
+hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
+tower-http = { version = "0.4", optional = true}
+rustls-pemfile = { version = "1", optional = true }
+tokio-rustls = { version = "0.24.0", optional = true }
+
 
 [dev-dependencies]
 tokio-test = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ thiserror = "1.0.56"
 tower-service = "0.3.2"
 # Needs to match tonics version of http, else implementations of the Service trait break.
 http = "0.2.0"
-tower = "0.4.13"
+tower = "0.4"
 
 # Dependencies for dangerous configuration
-hyper = { version = "0.14" }
+hyper = { version = "0.14", features = ["http2"] }
 hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
 tower-http = { version = "0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ tower-http = { version = "0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }
 tokio-rustls = { version = "0.24.0", optional = true, features = ["dangerous_configuration"] }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dev-dependencies]
 tokio-test = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tower-service = "0.3.2"
 http = "0.2.0"
 tower = "0.4.13"
 
-# Dependencies for dangerour configuration
+# Dependencies for dangerous configuration
 hyper = { version = "0.14" }
 hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
 tower-http = { version = "0.4", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/Lachstec/ginmi"
 doctest = false
 
 [features]
-dangerous_configuration = ["dep:hyper", "dep:hyper-rustls", "tower-http/util", "tower-http/add-extension", "dep:rustls-pemfile", "dep:tokio-rustls"]
+dangerous_configuration = ["dep:hyper-rustls", "tower-http/util", "tower-http/add-extension", "dep:rustls-pemfile", "dep:tokio-rustls"]
 
 [dependencies]
 tokio = { version = "1.35.1", features = ["rt-multi-thread", "macros"] }
@@ -31,7 +31,7 @@ http = "0.2.0"
 tower = "0.4.13"
 
 # Dependencies for dangerour configuration
-hyper = { version = "0.14", optional = true }
+hyper = { version = "0.14" }
 hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
 tower-http = { version = "0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hyper = { version = "0.14", optional = true }
 hyper-rustls = { version = "0.24.0", optional = true, features = ["http2"] }
 tower-http = { version = "0.4", optional = true}
 rustls-pemfile = { version = "1", optional = true }
-tokio-rustls = { version = "0.24.0", optional = true }
+tokio-rustls = { version = "0.24.0", optional = true, features = ["dangerous_configuration"] }
 
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -14,5 +14,6 @@ fn main() {
                 "proto/google.proto",
             ],
             &[proto_dir],
-        ).expect("Failed to compile protobuf files");
+        )
+        .expect("Failed to compile protobuf files");
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,64 +1,27 @@
-use http::{HeaderValue, Request};
-use std::error::Error;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use tonic::codegen::Body;
-use tower_service::Service;
+use tonic::metadata::AsciiMetadataValue;
+use tonic::{Request, Status};
+use tonic::service::Interceptor;
 
-/// Service that injects username and password into the request metadata
-#[derive(Debug, Clone)]
-pub struct AuthService<S> {
-    inner: S,
-    username: Option<Arc<HeaderValue>>,
-    password: Option<Arc<HeaderValue>>,
+pub struct AuthInterceptor {
+    username: AsciiMetadataValue,
+    password: AsciiMetadataValue,
 }
 
-impl<S> AuthService<S> {
-    #[inline]
-    pub fn new(
-        inner: S,
-        username: Option<Arc<HeaderValue>>,
-        password: Option<Arc<HeaderValue>>,
-    ) -> Self {
+impl AuthInterceptor {
+    pub fn new(username: Option<AsciiMetadataValue>, password: Option<AsciiMetadataValue>) -> Self {
         Self {
-            inner,
-            username,
-            password,
+            username: username.unwrap_or(AsciiMetadataValue::from_static("")),
+            password: password.unwrap_or(AsciiMetadataValue::from_static(""))
         }
     }
 }
 
-/// Implementation of Service so that it plays nicely with tonic.
-/// Trait bounds have to match those specified on [`tonic::client::GrpcService`]
-impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for AuthService<S>
-where
-    S: Service<Request<ReqBody>, Response = ResBody>,
-    S::Error: Into<Box<dyn Error + Send + Sync>>,
-    ResBody: Body,
-    <ResBody as Body>::Error: Into<Box<dyn Error + Send + Sync>>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    #[inline]
-    fn call(&mut self, mut request: Request<ReqBody>) -> Self::Future {
-        if let Some(user) = &self.username {
-            if let Some(pass) = &self.password {
-                request
-                    .headers_mut()
-                    .insert("username", user.as_ref().clone());
-                request
-                    .headers_mut()
-                    .insert("password", pass.as_ref().clone());
-            }
-        }
-
-        self.inner.call(request)
+impl Interceptor for AuthInterceptor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        request.metadata_mut()
+            .insert("username", self.username.clone());
+        request.metadata_mut()
+            .insert("password", self.password.clone());
+        Ok(request)
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,6 +2,7 @@ use tonic::metadata::AsciiMetadataValue;
 use tonic::{Request, Status};
 use tonic::service::Interceptor;
 
+#[derive(Debug, Clone)]
 pub struct AuthInterceptor {
     username: AsciiMetadataValue,
     password: AsciiMetadataValue,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 use tonic::metadata::AsciiMetadataValue;
-use tonic::{Request, Status};
 use tonic::service::Interceptor;
+use tonic::{Request, Status};
 
 #[derive(Debug, Clone)]
 pub struct AuthInterceptor {
@@ -12,16 +12,18 @@ impl AuthInterceptor {
     pub fn new(username: Option<AsciiMetadataValue>, password: Option<AsciiMetadataValue>) -> Self {
         Self {
             username: username.unwrap_or(AsciiMetadataValue::from_static("")),
-            password: password.unwrap_or(AsciiMetadataValue::from_static(""))
+            password: password.unwrap_or(AsciiMetadataValue::from_static("")),
         }
     }
 }
 
 impl Interceptor for AuthInterceptor {
     fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
-        request.metadata_mut()
+        request
+            .metadata_mut()
             .insert("username", self.username.clone());
-        request.metadata_mut()
+        request
+            .metadata_mut()
             .insert("password", self.password.clone());
         Ok(request)
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -33,7 +33,7 @@ impl<S> AuthService<S> {
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for AuthService<S>
 where
     S: Service<Request<ReqBody>, Response = ResBody>,
-    S::Error:,
+    S::Error: Into<Box<dyn Error + Send + Sync>>,
     ResBody: Body,
     <ResBody as Body>::Error: Into<Box<dyn Error + Send + Sync>>,
 {

--- a/src/client/capabilities.rs
+++ b/src/client/capabilities.rs
@@ -1,6 +1,5 @@
 use crate::gen::gnmi::CapabilityResponse;
 use crate::gen::gnmi::ModelData;
-use crate::Client;
 
 pub use crate::gen::gnmi::Encoding;
 

--- a/src/client/capabilities.rs
+++ b/src/client/capabilities.rs
@@ -1,6 +1,6 @@
-use crate::Client;
 use crate::gen::gnmi::CapabilityResponse;
 use crate::gen::gnmi::ModelData;
+use crate::Client;
 
 pub use crate::gen::gnmi::Encoding;
 
@@ -71,7 +71,7 @@ impl<'a> Capabilities {
         self.0.supported_models.contains(&ModelData {
             name: name.to_string(),
             organization: organization.to_string(),
-            version: version.to_string()
+            version: version.to_string(),
         })
     }
 
@@ -106,10 +106,9 @@ impl<'a> Capabilities {
             Encoding::Bytes => 1,
             Encoding::Proto => 2,
             Encoding::Ascii => 3,
-            Encoding::JsonIetf => 4
+            Encoding::JsonIetf => 4,
         };
 
         self.0.supported_encodings.contains(&enc)
     }
 }
-

--- a/src/client/capabilities.rs
+++ b/src/client/capabilities.rs
@@ -6,7 +6,7 @@ pub use crate::gen::gnmi::Encoding;
 /// Capabilities of a given gNMI Target device.
 ///
 /// Contains information about the capabilities that supported by a gNMI Target device.
-/// Obtained via [`Client::capabilities`].
+/// Obtained via [Client::capabilities](super::Client::capabilities).
 #[derive(Debug, Clone)]
 pub struct Capabilities(pub CapabilityResponse);
 
@@ -15,7 +15,7 @@ impl<'a> Capabilities {
     ///
     /// # Examples
     /// ```rust
-    /// # use ginmi::{Client, Capabilities};
+    /// # use ginmi::client::{Client, Capabilities};
     /// # fn main() -> std::io::Result<()> {
     /// # tokio_test::block_on(async {
     /// # const CERT: &str = "CA Certificate";
@@ -45,7 +45,7 @@ impl<'a> Capabilities {
     ///
     /// # Examples
     /// ```rust
-    /// # use ginmi::{Client, Capabilities};
+    /// # use ginmi::client::{Client, Capabilities};
     /// # fn main() -> std::io::Result<()> {
     /// # tokio_test::block_on(async {
     /// # const CERT: &str = "CA Certificate";
@@ -81,7 +81,7 @@ impl<'a> Capabilities {
     ///
     /// # Examples
     /// ```rust
-    /// # use ginmi::{Client, Capabilities, Encoding};
+    /// # use ginmi::client::{Client, Capabilities, Encoding};
     /// # fn main() -> std::io::Result<()> {
     /// # tokio_test::block_on(async {
     /// # const CERT: &str = "CA Certificate";

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -7,8 +7,6 @@ use super::capabilities::Capabilities;
 use super::dangerous::DangerousClientBuilder;
 use std::str::FromStr;
 use hyper::body::Bytes;
-#[cfg(feature = "dangerous_configuration")]
-use tokio_rustls::rustls::ClientConfig;
 use tonic::codegen::{Body, InterceptedService, StdError};
 use tonic::metadata::AsciiMetadataValue;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Uri};
@@ -70,11 +68,9 @@ pub struct Credentials<'a> {
 /// Used to configure and create instances of [`Client`].
 #[derive(Debug, Clone)]
 pub struct ClientBuilder<'a> {
-    target: &'a str,
-    creds: Option<Credentials<'a>>,
+    pub(crate) target: &'a str,
+    pub(crate) creds: Option<Credentials<'a>>,
     tls_settings: Option<ClientTlsConfig>,
-    #[cfg(feature = "dangerous_configuration")]
-    pub(crate) client_config: Option<ClientConfig>
 }
 
 impl<'a> ClientBuilder<'a> {
@@ -83,8 +79,6 @@ impl<'a> ClientBuilder<'a> {
             target,
             creds: None,
             tls_settings: None,
-            #[cfg(feature = "dangerous_configuration")]
-            client_config: None,
         }
     }
 

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -97,7 +97,7 @@ impl<'a> ClientBuilder<'a> {
         self.tls_settings = Some(settings);
         self
     }
-    
+
     #[cfg(feature = "dangerous_configuration")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
     /// Access configuration options that are dangerous and require extra care.

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -97,8 +97,10 @@ impl<'a> ClientBuilder<'a> {
         self.tls_settings = Some(settings);
         self
     }
-
+    
     #[cfg(feature = "dangerous_configuration")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
+    /// Access configuration options that are dangerous and require extra care.
     pub fn dangerous(self) -> DangerousClientBuilder<'a> {
         DangerousClientBuilder::from(self)
     }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -15,7 +15,7 @@ use tonic::transport::{Certificate, Channel, ClientTlsConfig, Uri};
 /// and manipulating configuration or querying telemetry.
 #[derive(Debug, Clone)]
 pub struct Client<T> {
-    inner: GNmiClient<T>,
+    pub(crate) inner: GNmiClient<T>,
 }
 
 impl<'a> Client<InterceptedService<Channel, AuthInterceptor>> {

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -8,7 +8,7 @@ use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use tokio_rustls::rustls::{Certificate, ClientConfig, Error, RootCertStore, ServerName};
 use tokio_rustls::rustls::client::{ServerCertVerifier, ServerCertVerified};
-use crate::GinmiError;
+use crate::{Client, GinmiError};
 use crate::gen::gnmi::g_nmi_client::GNmiClient;
 
 pub struct DangerousClientBuilder<'a> {
@@ -33,7 +33,7 @@ impl<'a> DangerousClientBuilder<'a> {
         self
     }
 
-    pub fn build(mut self) -> Result<GNmiClient<hyper::Client<HttpsConnector<HttpConnector>, tonic::body::BoxBody>>, GinmiError> {
+    pub async fn build(mut self) -> Result<Client<hyper::Client<HttpsConnector<HttpConnector>, tonic::body::BoxBody>>, GinmiError> {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
 
@@ -58,7 +58,9 @@ impl<'a> DangerousClientBuilder<'a> {
         
         let client = GNmiClient::with_origin(http_client, uri);
         
-        Ok(client)
+        Ok(Client {
+            inner: client
+        })
     }
 }
 

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -8,8 +8,14 @@ use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use tokio_rustls::rustls::{Certificate, ClientConfig, Error, RootCertStore, ServerName};
 use tokio_rustls::rustls::client::{ServerCertVerifier, ServerCertVerified};
+use tonic::body::BoxBody;
+use tonic::codegen::InterceptedService;
 use crate::{Client, GinmiError};
 use crate::gen::gnmi::g_nmi_client::GNmiClient;
+use crate::auth::AuthInterceptor;
+use crate::client::dangerous::service::AuthSvc;
+
+type DangerousClient = InterceptedService<hyper::Client<HttpsConnector<HttpConnector>, BoxBody>, AuthInterceptor>;
 
 pub struct DangerousClientBuilder<'a> {
     builder: ClientBuilder<'a>,
@@ -33,7 +39,7 @@ impl<'a> DangerousClientBuilder<'a> {
         self
     }
 
-    pub async fn build(mut self) -> Result<Client<hyper::Client<HttpsConnector<HttpConnector>, tonic::body::BoxBody>>, GinmiError> {
+    pub async fn build(mut self) -> Result<Client<DangerousClient>, GinmiError> {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
 
@@ -55,8 +61,12 @@ impl<'a> DangerousClientBuilder<'a> {
             Ok(u) => u,
             Err(e) => return Err(GinmiError::InvalidUriError(e.to_string())),
         };
-        
-        let client = GNmiClient::with_origin(http_client, uri);
+
+        let svc = tower::ServiceBuilder::new()
+            .layer(tonic::service::interceptor(AuthInterceptor::new(None, None)))
+            .service(http_client);
+
+        let client = GNmiClient::with_origin(svc, uri);
         
         Ok(Client {
             inner: client
@@ -79,5 +89,52 @@ struct NoCertificateVerification;
 impl ServerCertVerifier for NoCertificateVerification {
     fn verify_server_cert(&self, _end_entity: &Certificate, _intermediates: &[Certificate], _server_name: &ServerName, _scts: &mut dyn Iterator<Item=&[u8]>, _ocsp_response: &[u8], _now: SystemTime) -> Result<ServerCertVerified, Error> {
         Ok(ServerCertVerified::assertion())
+    }
+}
+
+mod service {
+    use http::{Request, Response};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tonic::body::BoxBody;
+    use tonic::transport::Body;
+    use tonic::transport::Channel;
+    use tower::Service;
+
+    pub struct AuthSvc {
+        inner: Channel,
+    }
+
+    impl AuthSvc {
+        pub fn new(inner: Channel) -> Self {
+            AuthSvc { inner }
+        }
+    }
+
+    impl Service<Request<BoxBody>> for AuthSvc {
+        type Response = Response<Body>;
+        type Error = Box<dyn std::error::Error + Send + Sync>;
+        #[allow(clippy::type_complexity)]
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx).map_err(Into::into)
+        }
+
+        fn call(&mut self, req: Request<BoxBody>) -> Self::Future {
+            // This is necessary because tonic internally uses `tower::buffer::Buffer`.
+            // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
+            // for details on why this is necessary
+            let clone = self.inner.clone();
+            let mut inner = std::mem::replace(&mut self.inner, clone);
+
+            Box::pin(async move {
+                // Do extra async work here...
+                let response = inner.call(req).await?;
+
+                Ok(response)
+            })
+        }
     }
 }

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -1,0 +1,45 @@
+use super::ClientBuilder;
+use std::convert::From;
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio_rustls::rustls::{Certificate, ClientConfig, Error, RootCertStore, ServerName};
+use tokio_rustls::rustls::client::{ServerCertVerifier, ServerCertVerified};
+
+pub struct DangerousClientBuilder<'a> {
+    builder: ClientBuilder<'a>,
+}
+
+impl<'a> DangerousClientBuilder<'a> {
+    pub fn disable_certificate_verification(mut self) -> ClientBuilder<'a> {
+        let roots = RootCertStore::empty();
+
+        let mut tls = ClientConfig::builder()
+            .with_safe_defaults()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        
+        tls.dangerous()
+            .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
+        
+        
+        self.builder.client_config = Some(tls);
+        self.builder
+    }
+}
+
+impl<'a> From<ClientBuilder<'a>> for DangerousClientBuilder<'a> {
+    fn from(builder: ClientBuilder<'a>) -> Self {
+        DangerousClientBuilder {
+            builder
+        }
+    }
+}
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(&self, _end_entity: &Certificate, _intermediates: &[Certificate], _server_name: &ServerName, _scts: &mut dyn Iterator<Item=&[u8]>, _ocsp_response: &[u8], _now: SystemTime) -> Result<ServerCertVerified, Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -83,7 +83,7 @@ impl<'a> DangerousClientBuilder<'a> {
     /// - Returns [`GinmiError::TransportError`] if the TLS-Settings are invalid.
     /// - Returns [`GinmiError::TransportError`] if a connection to the target could not be
     /// established.
-    pub async fn build(mut self) -> Result<Client<DangerousConnection>, GinmiError> {
+    pub async fn build(self) -> Result<Client<DangerousConnection>, GinmiError> {
         // create a hyper HttpConnector
         let mut http = HttpConnector::new();
         http.enforce_http(false);

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -12,10 +12,26 @@
 //! You should never use the functionality provided by this module, except when you need to test
 //! something locally and do not care for the certificates. Using this in the wild is very dangerous because
 //! you are susceptible to Man-in-the-Middle attacks.
+//! 
+//! # Examples
+//! Connecting to a SR-Linux device, ignoring any validation issues that happen with its certificate:
+//! ```rust
+//! # use ginmi::client::Client;
+//! # fn main() -> std::io::Result<()> {
+//! # tokio_test::block_on(async {
+//! # const CA_CERT: &str = "CA Certificate";
+//! let mut client = Client::builder("https://clab-srl01-srl:57400")
+//!     .credentials("admin", "password1")
+//!     .dangerous()
+//!     .disable_certificate_validation()
+//!     .build()
+//!     .await?;
+//! # })}
 use super::ClientBuilder;
 use crate::auth::AuthInterceptor;
 use crate::gen::gnmi::g_nmi_client::GNmiClient;
-use crate::{Client, GinmiError};
+use crate::client::Client;
+use crate::error::GinmiError;
 use http::Uri;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -12,7 +12,7 @@
 //! You should never use the functionality provided by this module, except when you need to test
 //! something locally and do not care for the certificates. Using this in the wild is very dangerous because
 //! you are susceptible to Man-in-the-Middle attacks.
-//! 
+//!
 //! # Examples
 //! Connecting to a SR-Linux device, ignoring any validation issues that happen with its certificate:
 //! ```rust
@@ -29,9 +29,9 @@
 //! # })}
 use super::ClientBuilder;
 use crate::auth::AuthInterceptor;
-use crate::gen::gnmi::g_nmi_client::GNmiClient;
 use crate::client::Client;
 use crate::error::GinmiError;
+use crate::gen::gnmi::g_nmi_client::GNmiClient;
 use http::Uri;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;

--- a/src/client/dangerous.rs
+++ b/src/client/dangerous.rs
@@ -8,9 +8,7 @@ use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use tokio_rustls::rustls::{Certificate, ClientConfig, Error, RootCertStore, ServerName};
 use tokio_rustls::rustls::client::{ServerCertVerifier, ServerCertVerified};
-use tonic::codegen::InterceptedService;
-use crate::auth::AuthInterceptor;
-use crate::{Client, GinmiError};
+use crate::GinmiError;
 use crate::gen::gnmi::g_nmi_client::GNmiClient;
 
 pub struct DangerousClientBuilder<'a> {
@@ -35,7 +33,7 @@ impl<'a> DangerousClientBuilder<'a> {
         self
     }
 
-    pub fn build(mut self) -> Result<GNmiClient<hyper::Client<HttpsConnector<HttpConnector>>>, GinmiError> {
+    pub fn build(mut self) -> Result<GNmiClient<hyper::Client<HttpsConnector<HttpConnector>, tonic::body::BoxBody>>, GinmiError> {
         let mut http = HttpConnector::new();
         http.enforce_http(false);
 
@@ -58,8 +56,9 @@ impl<'a> DangerousClientBuilder<'a> {
             Err(e) => return Err(GinmiError::InvalidUriError(e.to_string())),
         };
         
-        Ok(GNmiClient::with_origin(http_client, uri))
-
+        let client = GNmiClient::with_origin(http_client, uri);
+        
+        Ok(client)
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,11 +1,8 @@
-mod client;
 mod capabilities;
+mod client;
 #[cfg(feature = "dangerous_configuration")]
 mod dangerous;
 
 pub use client::{Client, ClientBuilder};
 
-pub use capabilities::{
-    Capabilities,
-    Encoding
-};
+pub use capabilities::{Capabilities, Encoding};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,12 +1,28 @@
+//! Provides a Client that can connect to gNMI-capable devices.
+//!
+//! The Client should be created by using the appropriate builder.
+//! Clients can be reused and are cheap to clone.
+//!
+//! # Examples
+//! Connecting to a Nokia SR-Linux Device running in [Containerlab](https://containerlab.dev/):
+//! ```rust
+//! # use ginmi::client::Client;
+//! fn main() -> std::io::Result<()> {
+//! # tokio_test::block_on(async {
+//! # const CA_CERT: &str = "CA Certificate";
+//! let mut client = Client::builder("https://clab-srl01-srl:57400")
+//!     .tls(CA_CERT, "clab-srl01-srl")
+//!     .credentials("admin", "password1")
+//!     .build()
+//!     .await?;
+//! # })}
+//! ```
 mod capabilities;
 mod client;
 #[cfg(feature = "dangerous_configuration")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
-mod dangerous;
+pub mod dangerous;
 
 pub use client::{Client, ClientBuilder};
 
 pub use capabilities::{Capabilities, Encoding};
-
-#[cfg(feature = "dangerous_configuration")]
-pub use dangerous::{DangerousClientBuilder, DangerousConnection};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,8 +1,12 @@
 mod capabilities;
 mod client;
 #[cfg(feature = "dangerous_configuration")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dangerous_configuration")))]
 mod dangerous;
 
 pub use client::{Client, ClientBuilder};
 
 pub use capabilities::{Capabilities, Encoding};
+
+#[cfg(feature = "dangerous_configuration")]
+pub use dangerous::{DangerousClientBuilder, DangerousConnection};

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,5 +1,7 @@
 mod client;
 mod capabilities;
+#[cfg(feature = "dangerous_configuration")]
+mod dangerous;
 
 pub use client::{Client, ClientBuilder};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ pub enum GinmiError {
     #[error("invalid uri passed as target: {}", .0)]
     InvalidUriError(String),
     #[error("invalid header in grpc request: {}", .0)]
-    InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
+    InvalidHeaderValue(#[from] tonic::metadata::errors::InvalidMetadataValue),
     #[error("error communicating with target device: {}", .0)]
     GrpcError(#[from] tonic::Status),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ mod error;
 pub use client::{Capabilities, Client, ClientBuilder, Encoding};
 pub use error::GinmiError;
 
+#[cfg(feature = "dangerous_configuration")]
+pub use client::{DangerousClientBuilder, DangerousConnection};
+
 pub(crate) mod gen {
     pub mod gnmi {
         tonic::include_proto!("gnmi");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,12 @@
 //!
 //! Provides a Client to modify and retrieve configuration from target network devices,
 //! as well as various telemetry data.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
 mod auth;
-mod client;
-mod error;
+pub mod client;
+pub mod error;
 
-pub use client::{Capabilities, Client, ClientBuilder, Encoding};
-pub use error::GinmiError;
-
-#[cfg(feature = "dangerous_configuration")]
-pub use client::{DangerousClientBuilder, DangerousConnection};
 
 pub(crate) mod gen {
     pub mod gnmi {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,11 @@
 //! A Rust client for the gRPC Network Management Interface
 //!
-//! Provides a Client to modify and retrieve configuration from target network devices,
-//! as well as various telemetry data.
+//! [ginmi](https://github.com/Lachstec/ginmi) is a crate based on [tonic](https://github.com/hyperium/tonic) for communicating with network
+//! devices that support [gNMI](https://openconfig.net/docs/gnmi/gnmi-specification/). It enables
+//! querying and manipulating of the device configuration and status.
+//! 
+//! # Feature Flags
+//! - `dangerous_configuration`: allows for insecure configurations, for example not validating TLS-Certificates
 mod auth;
 mod client;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,7 @@ mod auth;
 mod client;
 mod error;
 
-pub use client::{
-    Client,
-    ClientBuilder,
-    Encoding,
-    Capabilities
-};
+pub use client::{Capabilities, Client, ClientBuilder, Encoding};
 pub use error::GinmiError;
 
 pub(crate) mod gen {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ mod auth;
 pub mod client;
 pub mod error;
 
-
 pub(crate) mod gen {
     pub mod gnmi {
         tonic::include_proto!("gnmi");


### PR DESCRIPTION
This PR implements the option to entirely opt-out of server certificate validation when connecting to a device. Although dangerous and generally undesired, this makes quick testing and experimentation a bit more accessible. The dangerous code is locked behind the `dangerous_configuration` feature flag. Documentation was updated accordingly. Closes #13 